### PR TITLE
feat: Update odtp.yml to v0.5.0

### DIFF
--- a/odtp.yml
+++ b/odtp.yml
@@ -1,22 +1,34 @@
-# This file should contain basic component information for your component.
+# Schema version for tracking updates to the schema format
+schema-version: "v0.5.0"
+
+# Component Information
 component-name: odtp-component-example
-component-author: Carlos Vivar Rios
-component-version: v0.1.6
-component-repository: https://github.com/odtp-org/odtp-component-example
+component-version: "v0.1.7"
 component-license: AGPL-3.0
 component-type: ephemeral
 component-description: ODTP component to download a HF_DATASET
+component-authors:
+  - name: Carlos Vivar Rios
+    orcid: "https://orcid.org/0000-0002-8076-2034"
+component-repository:
+  url: "https://github.com/odtp-org/odtp-component-example"
+  doi: null
+component-docker-image: "caviri/odtp-component-example:v0.1.7"
 tags:
   - huggingface
   - testing
   - example
 
-# Information about the tools
+# Tool Information
 tools:
-  - tool-name: odtp-org/tool-example
-    tool-author: Carlos Vivar Rios
-    tool-version: 88f953f0aabbfb08189bdc3212aa1c209fbedb2d
-    tool-repository: 	https://github.com/odtp-org/tool-example
+  - tool-name: tool-example
+    tool-authors:
+      - name: Carlos Vivar Rios
+        orcid: "https://orcid.org/0000-0002-8076-2034"
+    tool-version: v0.1.0
+    tool-repository:
+      url: "https://github.com/odtp-org/tool-example"
+      doi: null
     tool-license: AGPL-3.0
 
 # If your tool require some secrets token to be passed as ENV to the component
@@ -34,11 +46,11 @@ ports: null
 # Datatype can be str, int, float, or bool.
 parameters:
   - name: HF_DATASET
-    default-value: rotten_tomatoes
+    default-value: "rotten_tomatoes"
     datatype: string
-    description: Hugging face dataset key
+    description: "Hugging face dataset ID"
     options:
-      - rotten_tomatoes
+      - "rotten_tomatoes"
     allow-custom-value: true
 
 # If applicable, data-input list required by the component
@@ -50,14 +62,20 @@ data-output:
     type: csv
     path: "{{HF_DATASET}}/test.csv"
     description: Output from dataset
+    dynamic-naming-based-on:
+      - HF_DATASET
   - name: train.csv
     type: csv
     path: "{{HF_DATASET}}/train.csv"
     description: Output from dataset
+    dynamic-naming-based-on:
+      - HF_DATASET
   - name: validation.csv
     type: csv
     path: "{{HF_DATASET}}/validation.csv"
     description: Output from dataset
+    dynamic-naming-based-on:
+      - HF_DATASET
 
 
 # If applicable, path to schemas to perform semantic validation.
@@ -67,4 +85,5 @@ schema-output: null
 
 # If applicable, define devices needed such as GPU.
 devices:
-  gpu: false
+  - type: gpu
+    required: true

--- a/odtp.yml
+++ b/odtp.yml
@@ -58,24 +58,20 @@ data-inputs: null
 
 # If applicable, data-output list produced by the component
 data-output:
+# If applicable, data-output list produced by the component
+data-output:
   - name: test.csv
     type: csv
     path: "{{HF_DATASET}}/test.csv"
     description: Output from dataset
-    dynamic-naming-based-on:
-      - HF_DATASET
   - name: train.csv
     type: csv
     path: "{{HF_DATASET}}/train.csv"
     description: Output from dataset
-    dynamic-naming-based-on:
-      - HF_DATASET
   - name: validation.csv
     type: csv
     path: "{{HF_DATASET}}/validation.csv"
     description: Output from dataset
-    dynamic-naming-based-on:
-      - HF_DATASET
 
 
 # If applicable, path to schemas to perform semantic validation.
@@ -86,4 +82,4 @@ schema-output: null
 # If applicable, define devices needed such as GPU.
 devices:
   - type: gpu
-    required: true
+    required: false


### PR DESCRIPTION
Update odtp.yml to newest odtp.yml version. This includes a better description of authors and tools used, information about dockerhub hosted images, and a proposal on dynamic naming convention:

v0.5.0 `odtp.yml` proposal is here
https://github.com/odtp-org/odtp-component-template/blob/main/odtp.yml